### PR TITLE
Add a script loader

### DIFF
--- a/src/dom/script-loader.ts
+++ b/src/dom/script-loader.ts
@@ -1,0 +1,78 @@
+import { time } from '../time/time';
+
+export interface ScriptLoaderConfig {
+  /**
+   * A function used to verify the script has successfully loaded.
+   */
+  test: () => boolean;
+
+  /**
+   * Timeout, in ms. Defaults to 5000ms.
+   */
+  timeout?: number;
+}
+
+/**
+ * A script loader that checks to verify if the script has loaded by repeatedly
+ * calling a test method using RAF.
+ *
+ * Example loading the YT API:
+ *
+ * ```
+ * const scriptLoader = new RAFScriptLoader();
+ * scriptLoader.load('https://www.youtube.com/iframe_api', {
+ *   test: () => window.YT,
+ * }).then(() => {
+ *   // The YT API should be loaded now.
+ *   const player = new YT.Player(...);
+ * });
+ * ```
+ */
+export class ScriptLoader {
+  /**
+   * Loads a script element onto the page.
+   *
+   * @param url The script src.
+   * @param test A function used to verify the script has successfully loaded.
+   * @param options Config options for loading the script.
+   */
+  public load(url: string, options: ScriptLoaderConfig): Promise<void> {
+    const timeout = options.timeout || 5000;
+    return new Promise((resolve, reject) => {
+      // Avoid adding the script to the page if the test fn already passes.
+      if (options.test()) {
+        resolve();
+        return;
+      }
+
+      // Render the <script> tag to the DOM.
+      this.renderDom(url);
+
+      // Using RAF, repeatedly check if the script has been loaded.
+      const startTime = time.now();
+      const callback = () => {
+        if (options.test()) {
+          resolve();
+          return;
+        }
+        const elapsed = time.now() - startTime;
+        if (elapsed > timeout) {
+          reject(`failed to load ${url} due to timeout`);
+          return;
+        }
+        window.requestAnimationFrame(callback);
+      };
+      window.requestAnimationFrame(callback);
+    });
+  }
+
+  /**
+   * Renders the DOM for the script element. Subclasses should override this
+   * method for more complex script renderings.
+   */
+  protected renderDom(url: string): void {
+    const script = document.createElement('script');
+    script.src = url;
+    document.body.appendChild(script);
+  }
+}

--- a/src/loader/script-loader.ts
+++ b/src/loader/script-loader.ts
@@ -30,6 +30,7 @@ export interface ScriptLoaderConfig {
  */
 export class ScriptLoader {
   private loadedScripts: Record<string, Promise<void>> = {};
+  private disposed = false;
 
   /**
    * Loads a script element onto the page.
@@ -59,6 +60,10 @@ export class ScriptLoader {
       const startTime = time.now();
       const timeout = options.timeout || 5000;
       const callback = () => {
+        if (this.disposed) {
+          reject('script loader is disposed');
+          return;
+        }
         if (options.test()) {
           resolve();
           return;
@@ -85,5 +90,10 @@ export class ScriptLoader {
     const script = document.createElement('script');
     script.src = url;
     document.body.appendChild(script);
+  }
+
+  dispose() {
+    this.loadedScripts = {};
+    this.disposed = true;
   }
 }

--- a/src/loader/script-loader.ts
+++ b/src/loader/script-loader.ts
@@ -1,5 +1,3 @@
-import { time } from '../time/time';
-
 export interface ScriptLoaderConfig {
   /**
    * A function used to verify the script has successfully loaded.
@@ -57,7 +55,7 @@ export class ScriptLoader {
       this.renderDom(url);
 
       // Using RAF, repeatedly check if the script has been loaded.
-      const startTime = time.now();
+      const startTime = Date.now();
       const timeout = options.timeout || 5000;
       const callback = () => {
         if (this.disposed) {
@@ -68,7 +66,7 @@ export class ScriptLoader {
           resolve();
           return;
         }
-        const elapsed = time.now() - startTime;
+        const elapsed = Date.now() - startTime;
         if (elapsed > timeout) {
           reject(`failed to load ${url} due to timeout`);
           return;


### PR DESCRIPTION
The script loader is meant to be used for 3rd party scripts that should be loaded upon interaction, such as the YouTube API. Example usage is something like:

```javascript
const scriptLoader = new ScriptLoader();
scriptLoader.load('https://www.youtube.com/iframe_api', {
  test: () => window.YT,
}).then(() => {
  // do something with the youtube api
});
```

With the example code above, if the `test` function returns `true` right from the get-go, the script isn't added to the page at all. A class is used here so that the `renderDom()` method can be overridden for special use cases, like if a site is enabled for CORS and needs to be safe-loaded through some special mechanism.

A similar utility can be found in the Closure Library here: https://github.com/google/closure-library/blob/master/closure/goog/net/jsloader.js

Let me know if any feedback, happy to address.